### PR TITLE
genOpen: Check if memory card is formatted before attempting open

### DIFF
--- a/filer.c
+++ b/filer.c
@@ -968,6 +968,18 @@ int genRemove(char *path)
 int genOpen(char *path, int mode)
 {
     genLimObjName(path, 0);
+    // Don't attempt to read the memory cards if they are unformatted
+    // This can result in a deadlock and a pretty nice looking black screen
+    if (!strncmp(path, "mc", 2)) {
+        int formatted;
+        mcSync(0, NULL, NULL);
+        mcGetInfo(path[2] - '0', 0, NULL, NULL, &formatted);
+        mcSync(0, NULL, NULL);
+        if (!formatted) {
+            DPRINTF("Memory card is not formatted, skipping genOpen.\n");
+            return -1;
+        }
+    }
     return open(path, mode, fileMode);
 }
 //------------------------------


### PR DESCRIPTION
Fixes a black screen on launch issue when an unformatted memory card is inserted. Reproducible on PCSX2.

## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Reproduce-able on hardware and on PCSX2.
wLaunchELF checks for "related files" on multiple devices, including memory cards. On opens to unformatted memory cards, the IOP will stall, making the EE stuck forever. These changes check the status of the memory card, and if it is unformatted, skips trying to open a file on it.

These changes could possibly be instead, put into the fileXio / whatever memory card library instead of doing the check here.
Suggestions and ideas are welcome.

I believe this happened during v4.40, the changelog states "-Merged in a new mcman module by jimmikaelkael, fixing the FTP server bug". Possibly fixing mcman itself would be a better solution?