### PR TITLE
Revert "Align iox_dirent_t structures"

### DIFF
--- a/filer.c
+++ b/filer.c
@@ -684,7 +684,7 @@ int readMC(const char *path, FILEINFO *info, int max)
 //--------------------------------------------------------------
 int readCD(const char *path, FILEINFO *info, int max)
 {
-    iox_dirent_t record __attribute__((aligned(64)));
+    iox_dirent_t record;
     int n = 0, dd = -1;
     u64 wait_start;
 
@@ -738,7 +738,7 @@ exit:
 //--------------------------------------------------------------
 void setPartyList(void)
 {
-    iox_dirent_t dirEnt __attribute__((aligned(64)));
+    iox_dirent_t dirEnt;
     int hddFd;
 
     nparties = 0;
@@ -776,7 +776,7 @@ void setPartyList(void)
 //--------------------------------------------------------------
 void setDVRPPartyList(void)
 {
-    iox_dirent_t dirEnt __attribute__((aligned(64)));
+    iox_dirent_t dirEnt;
     int hddFd;
 
     ndvrpparties = 0;
@@ -1056,7 +1056,7 @@ int genCmpFileExt(const char *filename, const char *extension)
 //--------------------------------------------------------------
 int readVMC(const char *path, FILEINFO *info, int max)
 {
-    iox_dirent_t dirbuf __attribute__((aligned(64)));
+    iox_dirent_t dirbuf;
     char dir[MAX_PATH];
     int i = 0, fd;
 
@@ -1110,7 +1110,7 @@ int readVMC(const char *path, FILEINFO *info, int max)
 //--------------------------------------------------------------
 int readHDD(const char *path, FILEINFO *info, int max)
 {
-    iox_dirent_t dirbuf __attribute__((aligned(64)));
+    iox_dirent_t dirbuf;
     char party[MAX_PATH], dir[MAX_PATH];
     int i = 0, fd, ret;
 
@@ -1172,7 +1172,7 @@ int readHDD(const char *path, FILEINFO *info, int max)
 //--------------------------------------------------------------
 int readHDDDVRP(const char *path, FILEINFO *info, int max)
 {
-    iox_dirent_t dirbuf __attribute__((aligned(64)));
+    iox_dirent_t dirbuf;
     char party[MAX_PATH], dir[MAX_PATH];
     int i = 0, fd, ret;
 
@@ -1258,7 +1258,7 @@ void scan_USB_mass(void)
 //--------------------------------------------------------------
 int readMASS(const char *path, FILEINFO *info, int max)
 {
-    iox_dirent_t record __attribute__((aligned(64)));
+    iox_dirent_t record;
     int n = 0, dd = -1;
 
     if (!USB_mass_scanned)
@@ -1359,7 +1359,7 @@ void initHOST(void)
 //--------------------------------------------------------------
 int readHOST(const char *path, FILEINFO *info, int max)
 {
-    iox_dirent_t hostcontent __attribute__((aligned(64)));
+    iox_dirent_t hostcontent;
     int hfd, rv, hostcount = 0;
     char *elflisttxt;
     char host_path[MAX_PATH * 2];

--- a/hdd.c
+++ b/hdd.c
@@ -97,7 +97,7 @@ void DebugDispStat(iox_dirent_t *p)
 //--------------------------------------------------------------
 void GetHddInfo(void)
 {
-    iox_dirent_t infoDirEnt __attribute__((aligned(64)));
+    iox_dirent_t infoDirEnt;
     int rv, hddFd = 0, partitionFd, i, Treat = TREAT_NOACCESS, tooManyPartitions;
     u32 size = 0, zoneFree, zoneSize;
     char tmp[MAX_PATH];


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [x] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

This reverts commit bad078d7228157e821c329fdcaa2f3cf5ffd7732.

The SDK now aligns the appropriate fileXio structures.