### PR TITLE
HddManager: disable the expand option, since it causes corruption

### DIFF
--- a/hdd.c
+++ b/hdd.c
@@ -382,6 +382,8 @@ int MenuParty(PARTYINFO Info)
     if (Info.Treatment == TREAT_NOACCESS) {
         enable[EXPAND] = FALSE;
     }
+    // FIXME: Always disable the expand option, since it causes corruption
+    enable[EXPAND] = FALSE;
 
     for (sel = 0; sel < NUM_MENU; sel++)
         if (enable[sel] == TRUE)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Disable the expand option; it doesn't work correctly and may cause corruption.  
I believe this was already done in kHn LE fork.  