### PR TITLE
Fix alignment of variables in IOP modules to be max 16 bytes

### DIFF
--- a/hdl_info/main.c
+++ b/hdl_info/main.c
@@ -22,9 +22,9 @@ int __attribute__((unused)) shutdown() { return 0; }
 void rpcMainThread(void *param);
 void *rpcCommandHandler(int command, void *Data, int Size);
 
-static SifRpcDataQueue_t Rpc_Queue __attribute__((aligned(64)));
-static SifRpcServerData_t Rpc_Server __attribute((aligned(64)));
-static int Rpc_Buffer[1024] __attribute((aligned(64)));
+static SifRpcDataQueue_t Rpc_Queue __attribute__((__aligned__(16)));
+static SifRpcServerData_t Rpc_Server __attribute__((__aligned__(16)));
+static int Rpc_Buffer[1024] __attribute__((__aligned__(16)));
 
 /* Description: Module entry point */
 int _start(int argc, char **argv)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

The IRX loader can only handle max alignment of 16 bytes.  
Future updates to the toolchain will make this a hard requirement.