### PR TITLE
also check errno when lseek64 returns -1

### DIFF
--- a/config.c
+++ b/config.c
@@ -280,7 +280,7 @@ test:
 char *preloadCNF(char *path)
 {
     int fd, tst;
-    size_t CNF_size;
+    s64 CNF_size;
     char cnf_path[MAX_PATH];
     char *RAM_p;
 
@@ -292,7 +292,7 @@ char *preloadCNF(char *path)
         return NULL;
     }
     CNF_size = genLseek(fd, 0, SEEK_END);
-    printf("CNF_size=%lu\n", (unsigned long)CNF_size);
+    printf("CNF_size=%lld\n", CNF_size);
     genLseek(fd, 0, SEEK_SET);
     RAM_p = (char *)memalign(64, CNF_size);
     if (RAM_p == NULL) {

--- a/filer.c
+++ b/filer.c
@@ -2,6 +2,7 @@
 // File name:   filer.c
 //--------------------------------------------------------------
 #include "launchelf.h"
+#include <errno.h>
 
 typedef struct
 {
@@ -1008,7 +1009,7 @@ int genDopen(char *path)
 s64 genLseek(int fd, s64 where, int how)
 {
     s64 res = lseek64(fd, where, how);
-    if (res == -48) {
+    if (res == -48 || (res == -1 && errno == 48)) {
         res = lseek(fd, where, how);
     }
     return res;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
in `genLseek` the return value of `lseek64` is checked against the error value `-48` but it should also check against the `-1` return code and the value `48` in `errno`. This fixes  #116 allowing PS2 games to boot using `PS2Disc`.