### PR TITLE
fix: Stop using long type

### DIFF
--- a/config.c
+++ b/config.c
@@ -135,9 +135,9 @@ int CheckMC(void)
     return -11;
 }
 //---------------------------------------------------------------------------
-unsigned long hextoul(const char *string)
+u32 hextou32(const char *string)
 {
-    unsigned long value;
+    u32 value;
     char c;
 
     value = 0;
@@ -313,21 +313,21 @@ char *preloadCNF(const char *path)
 int scanSkinCNF(const char *name, const char *value)
 {
     if (!strcmp(name, "GUI_Col_1_ABGR"))
-        setting->color[COLOR_BACKGR] = hextoul(value);
+        setting->color[COLOR_BACKGR] = hextou32(value);
     else if (!strcmp(name, "GUI_Col_2_ABGR"))
-        setting->color[COLOR_FRAME] = hextoul(value);
+        setting->color[COLOR_FRAME] = hextou32(value);
     else if (!strcmp(name, "GUI_Col_3_ABGR"))
-        setting->color[COLOR_SELECT] = hextoul(value);
+        setting->color[COLOR_SELECT] = hextou32(value);
     else if (!strcmp(name, "GUI_Col_4_ABGR"))
-        setting->color[COLOR_TEXT] = hextoul(value);
+        setting->color[COLOR_TEXT] = hextou32(value);
     else if (!strcmp(name, "GUI_Col_5_ABGR"))
-        setting->color[COLOR_GRAPH1] = hextoul(value);
+        setting->color[COLOR_GRAPH1] = hextou32(value);
     else if (!strcmp(name, "GUI_Col_6_ABGR"))
-        setting->color[COLOR_GRAPH2] = hextoul(value);
+        setting->color[COLOR_GRAPH2] = hextou32(value);
     else if (!strcmp(name, "GUI_Col_7_ABGR"))
-        setting->color[COLOR_GRAPH3] = hextoul(value);
+        setting->color[COLOR_GRAPH3] = hextou32(value);
     else if (!strcmp(name, "GUI_Col_8_ABGR"))
-        setting->color[COLOR_GRAPH4] = hextoul(value);
+        setting->color[COLOR_GRAPH4] = hextou32(value);
     //----------
     else if (!strcmp(name, "SKIN_FILE"))
         strcpy(setting->skin, value);

--- a/filer.c
+++ b/filer.c
@@ -119,7 +119,7 @@ int host_error = 0;
 int host_elflist = 0;
 int host_use_Bsl = 1;  // By default assume that host paths use backslash
 
-unsigned long written_size;  // Used for pasting progress report
+u64 written_size;  // Used for pasting progress report
 u64 PasteTime;               // Used for pasting progress report
 
 typedef struct
@@ -2250,7 +2250,7 @@ int copy(const char *outPath, const char *inPath, FILEINFO file, int recurses)
     sceMcTblGetDir stats;
     int speed = 0;
     int remain_time = 0, TimeDiff = 0;
-    long old_size = 0, SizeDiff = 0;
+    s64 old_size = 0, SizeDiff = 0;
     u64 OldTime = 0LL;
     psu_header PSU_head;
     mcT_header *mcT_head_p = (mcT_header *)&file.stats;
@@ -2744,9 +2744,9 @@ non_PSU_RESTORE_init:
         sprintf(tmp, "\n%s : ", LNG(Remain_Size));
         strcat(progress, tmp);
         if (size <= 1024)
-            sprintf(tmp, "%lu %s", (unsigned long)size, LNG(bytes));  // bytes
+            sprintf(tmp, "%llu %s", (u64)size, LNG(bytes));  // bytes
         else
-            sprintf(tmp, "%lu %s", (unsigned long)size / 1024, LNG(Kbytes));  // Kbytes
+            sprintf(tmp, "%llu %s", (u64)size / 1024, LNG(Kbytes));  // Kbytes
         strcat(progress, tmp);
 
         sprintf(tmp, "\n%s: ", LNG(Current_Speed));
@@ -2773,7 +2773,7 @@ non_PSU_RESTORE_init:
 
         sprintf(tmp, "\n\n%s: ", LNG(Written_Total));
         strcat(progress, tmp);
-        sprintf(tmp, "%lu %s", written_size / 1024, LNG(Kbytes));  // Kbytes
+        sprintf(tmp, "%llu %s", written_size / 1024, LNG(Kbytes));  // Kbytes
         strcat(progress, tmp);
 
         sprintf(tmp, "\n%s: ", LNG(Average_Speed));
@@ -4170,7 +4170,7 @@ int getFilePath(char *out, int cnfmode)
                     printXY(tmp, x + 4, y, color, TRUE, name_limit);
                 if (file_show > 0) {
                     //					unsigned int size = files[top+i].stats.fileSizeByte;
-                    unsigned long long size = ((unsigned long long)files[top + i].stats.Reserve2 << 32) | files[top + i].stats.FileSizeByte;
+                    u64 size = ((u64)files[top + i].stats.Reserve2 << 32) | files[top + i].stats.FileSizeByte;
                     PS2TIME timestamp = *(PS2TIME *)&files[top + i].stats._Modify;
 
                     if (!size_valid)
@@ -4189,8 +4189,7 @@ int getFilePath(char *out, int cnfmode)
                             size /= 1024;
                         }
                         //						sprintf(tmp, "%5u%cB", size, scale_s[scale]);
-                        // size shouldn't be over 99999, and seems sprintf doesn't support unsigned long long (%llu crashes)
-                        sprintf(tmp, "%5u%cB", (unsigned)size, scale_s[scale]);
+                        sprintf(tmp, "%5llu%cB", size, scale_s[scale]);
                     }
 
                     if (!time_valid || !(top + i))
@@ -4420,7 +4419,7 @@ void submenu_func_GetSize(char *mess, const char *path, FILEINFO *files)
             text_pos += text_inc;
         }
         // sprintf(mess+text_pos, " mcTsz=%d%n", files[sel].stats.fileSizeByte, &text_inc);
-        size = ((unsigned long long)files[sel].stats.Reserve2 << 32) | files[sel].stats.FileSizeByte;
+        size = ((u64)files[sel].stats.Reserve2 << 32) | files[sel].stats.FileSizeByte;
         // Max length is 20 characters+NULL
         char sizeC[21] = {0};
         char *sizeP = &sizeC[21];

--- a/ps2host/net_fio.c
+++ b/ps2host/net_fio.c
@@ -416,7 +416,7 @@ int pko_read_file(int fd, char *buf, int length)
 
 //----------------------------------------------------------------------
 //
-int pko_ioctl(int fd, unsigned long request, const void *data)
+int pko_ioctl(int fd, int request, const void *data)
 {
     pko_pkt_ioctl_req *ioctlreq;
     pko_pkt_file_rly *ioctlrly;

--- a/ps2host/net_fio.h
+++ b/ps2host/net_fio.h
@@ -23,7 +23,7 @@ int pko_open_dir(const char *path);
 int pko_read_dir(int fd, void *buf);
 int pko_close_dir(int fd);
 int pko_make_dir(char *path);
-int pko_ioctl(int fd, unsigned long request, const void *data);
+int pko_ioctl(int fd, int request, const void *data);
 int pko_remove(const char *name);
 int pko_mkdir(const char *name, int mode);
 int pko_rmdir(const char *name);

--- a/ps2host/net_fsys.c
+++ b/ps2host/net_fsys.c
@@ -230,7 +230,7 @@ static int fsysLseek(int fd, unsigned int offset, int whence)
     return ret;
 }
 //----------------------------------------------------------------------------
-static int fsysIoctl(iop_file_t *file, unsigned long request, void *data)
+static int fsysIoctl(iop_file_t *file, int request, void *data)
 {
     int ret;
     dbgprintf("fsysioctl..\n");


### PR DESCRIPTION
The upgrade to GCC > 3 caused long type from 64 to 32 bits, so fix that

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Fixes #125 