### PR TITLE
change: use smap-ps2ip instead of netman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SIO_DEBUG ?= 0
 EE_BIN = BOOT-UNC.ELF
 EE_BIN_PKD = BOOT.ELF
 EE_OBJS = main.o pad.o config.o elf.o draw.o loader_elf.o filer.o \
-	poweroff_irx.o iomanx_irx.o filexio_irx.o ps2atad_irx.o ps2dev9_irx.o ps2ip_irx.o netman_irx.o \
+	poweroff_irx.o iomanx_irx.o filexio_irx.o ps2atad_irx.o ps2dev9_irx.o ps2ip_irx.o \
 	ps2smap_irx.o ps2hdd_irx.o ps2fs_irx.o ps2netfs_irx.o usbd_irx.o bdm_irx.o bdmfs_fatfs_irx.o usbmass_bd_irx.o mcman_irx.o mcserv_irx.o\
 	extflash_irx.o xfromman_irx.o \
 	dvrdrv_irx.o dvrfile_irx.o \
@@ -112,13 +112,10 @@ $(EE_ASM_DIR)filexio_irx.c: $(PS2SDK)/iop/irx/fileXio.irx | $(EE_ASM_DIR)
 $(EE_ASM_DIR)ps2dev9_irx.c: $(PS2SDK)/iop/irx/ps2dev9.irx | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ ps2dev9_irx
 
-$(EE_ASM_DIR)ps2ip_irx.c: $(PS2SDK)/iop/irx/ps2ip-nm.irx | $(EE_ASM_DIR)
+$(EE_ASM_DIR)ps2ip_irx.c: $(PS2SDK)/iop/irx/ps2ip.irx | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ ps2ip_irx
 
-$(EE_ASM_DIR)netman_irx.c: $(PS2SDK)/iop/irx/netman.irx | $(EE_ASM_DIR)
-	$(BIN2C) $< $@ netman_irx
-
-$(EE_ASM_DIR)ps2smap_irx.c: $(PS2SDK)/iop/irx/smap.irx | $(EE_ASM_DIR)
+$(EE_ASM_DIR)ps2smap_irx.c: $(PS2SDK)/iop/irx/smap-ps2ip.irx | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ ps2smap_irx
 
 oldlibs/ps2ftpd/ps2ftpd.irx: oldlibs/ps2ftpd

--- a/main.c
+++ b/main.c
@@ -15,8 +15,6 @@ extern u8 ps2dev9_irx[];
 extern int size_ps2dev9_irx;
 extern u8 ps2ip_irx[];
 extern int size_ps2ip_irx;
-extern u8 netman_irx[];
-extern int size_netman_irx;
 extern u8 ps2smap_irx[];
 extern int size_ps2smap_irx;
 extern u8 ps2host_irx[];
@@ -139,7 +137,6 @@ static u8 have_hdl_info = 0;
 // State of Checkable Modules (valid header)
 static u8 have_poweroff = 0;
 static u8 have_ps2dev9 = 0;
-static u8 have_netman = 0;
 static u8 have_ps2ip = 0;
 static u8 have_ps2atad = 0;
 static u8 have_ps2hdd = 0;
@@ -706,18 +703,14 @@ static void load_ps2ip(void)
     int ret;
 
     load_ps2dev9();
-    if (!have_netman) {
-        SifExecModuleBuffer(netman_irx, size_netman_irx, 0, NULL, &ret);
-        have_netman = 1;
+    if (!have_ps2ip) {
+        SifExecModuleBuffer(ps2ip_irx, size_ps2ip_irx, 0, NULL, &ret);
+        have_ps2ip = 1;
     }
     if (!have_ps2smap) {
         SifExecModuleBuffer(ps2smap_irx, size_ps2smap_irx,
                             if_conf_len, &if_conf[0], &ret);
         have_ps2smap = 1;
-    }
-    if (!have_ps2ip) {
-        SifExecModuleBuffer(ps2ip_irx, size_ps2ip_irx, 0, NULL, &ret);
-        have_ps2ip = 1;
     }
 }
 //------------------------------
@@ -2159,7 +2152,6 @@ static void Reset()
     have_cdvd = 0;
     have_usbd = 0;
     have_usb_mass = 0;
-    have_netman = 0;
     have_ps2smap = 0;
     have_ps2host = 0;
     have_vmc_fs = 0;


### PR DESCRIPTION
Networking now works as before

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Fixes #134 
Fixes #123 
Fixes #109