### PR TITLE
Fix SELECT+START to open Configure instead of resetting settings

### DIFF
--- a/main.c
+++ b/main.c
@@ -2512,8 +2512,13 @@ int main(int argc, char *argv[])
             switch (mode) {
                 case BUTTON:
                     if ((new_pad & PAD_SELECT) && (new_pad & PAD_START)) {
-                        initConfig();
-                        updateScreenMode();
+                        if (setting->GUI_skin[0]) {
+                            GUI_active = 0;
+                            loadSkin(BACKGROUND_PIC, 0, 0);
+                            Load_External_Language();
+                            loadFont(setting->font_file);
+                        }
+                        config(mainMsg, CNF);
                     } else if (new_pad & PAD_CIRCLE)
                         RunELF_index = SETTING_LK_CIRCLE;
                     else if (new_pad & PAD_CROSS)


### PR DESCRIPTION
SELECT+START at the main menu called initConfig(), which wiped in-memory settings to factory defaults without opening the config screen. Match the Misc_Configure path and call config() instead.

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
