### PR TITLE
fix: clearer color labels in Screen Settings (Fixes #128)

### DIFF
--- a/config.c
+++ b/config.c
@@ -1392,9 +1392,15 @@ static void Config_Screen(void)
                 else if (i == COLOR_SELECT)
                     sprintf(c, "%s", LNG(Select));
                 else if (i == COLOR_TEXT)
-                    sprintf(c, "%s", LNG(Normal));
-                else if (i >= COLOR_GRAPH1)
-                    sprintf(c, "%s%d", LNG(Graph), i - COLOR_GRAPH1 + 1);
+                    sprintf(c, "%s", LNG(Color_Text));
+                else if (i == COLOR_GRAPH1)
+                    sprintf(c, "%s", LNG(Color_Folders));
+                else if (i == COLOR_GRAPH2)
+                    sprintf(c, "%s", LNG(Color_ELFs));
+                else if (i == COLOR_GRAPH3)
+                    sprintf(c, "%s", LNG(Color_NotReadable));
+                else if (i == COLOR_GRAPH4)
+                    sprintf(c, "%s", LNG(Color_FileReadable));
                 printXY(c, x + (space * (i + 1)) - (printXY(c, 0, 0, 0, FALSE, space - FONT_WIDTH / 2) / 2), y + FONT_HEIGHT,
                         setting->color[COLOR_TEXT], TRUE, space - FONT_WIDTH / 2);
                 y += FONT_HEIGHT * 2;

--- a/lang.h
+++ b/lang.h
@@ -377,6 +377,12 @@ lang(325, Unload_HDL_Game_Info, "Unload HDL Game Info")
 lang(326, HDD_Information_Read_Overflow, "HDD Information Read (truncated)")
 //---------------------------------------------------------------------------
 lang(327, Loading_Flash_Modules, "Loading Flash Modules...")
+//---------------------------------------------------------------------------
+lang(328, Color_Text, "Text")
+lang(329, Color_Folders, "Folders")
+lang(330, Color_ELFs, "ELFs")
+lang(331, Color_NotReadable, "Not Readable")
+lang(332, Color_FileReadable, "File Readable")
 
     // clang-format on
     //---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Renames Screen Settings color labels (Color4–8) so users can see what each color actually affects in the UI. Addresses #128.

| Color | Before | After |
|-------|--------|-------|
| Color4 | Normal | Text |
| Color5 | Graph1 | Folders |
| Color6 | Graph2 | ELFs |
| Color7 | Graph3 | Not Readable |
| Color8 | Graph4 | File Readable |

Colors 1–3 (Backgr, Frames, Select) are unchanged.

## Details

- Added dedicated strings in `lang.h` (`Color_Text`, `Color_Folders`, etc.) so existing `Normal` / `Graph` strings stay available elsewhere (e.g. other menus).
- Updated the label display loop in `config.c` only; no change to color values, CNF keys (`GUI_Col_*`), or file-browser logic.
